### PR TITLE
fixed i7 7700k cache size and added surface 4 pro

### DIFF
--- a/benchmark.html
+++ b/benchmark.html
@@ -48,7 +48,7 @@ sitemap:
 					<td>Gaming Rig</td>
                                         <td>Intel Core i7 7700k</td>
                                         <td>4.8</td>
-                                        <td>32 MB</td>
+                                        <td>8 MB</td>
                                         <td>DDR4</td>
                                         <td>16</td>
                                         <td>3200</td>
@@ -84,6 +84,20 @@ sitemap:
                                         <td>FF Quantum</td>
                                         <td>Centos 7</td>
                                         <td>32</td>
+                                        <td>None</td>
+                                </tr>
+				<tr>
+                                        <td>Surface Pro 4</td>
+                                        <td>i5-6300U</td>
+                                        <td>2.4</td>
+                                        <td>3MB L3</td>
+                                        <td>DDR</td>
+                                        <td>8</td>
+                                        <td>?</td>
+                                        <td>2.2</td>
+                                        <td>FF Quantum</td>
+                                        <td>Windows 10 Pro</td>
+                                        <td>4</td>
                                         <td>None</td>
                                 </tr>
 			</tbody>


### PR DESCRIPTION
i7 7700k has 8MB cache, not 32MB
source: https://ark.intel.com/products/97129/Intel-Core-i7-7700K-Processor-8M-Cache-up-to-4_50-GHz

added surface 4 pro, couldn't find the ram type and speed anywhere.