### PR TITLE
Added benchmark for "GCloud 16 vCPU"

### DIFF
--- a/benchmark.html
+++ b/benchmark.html
@@ -406,6 +406,20 @@ sitemap:
         <td>24</td>
         <td>None</td>
     </tr>
+    <tr>
+        <td>Google Cloud 16 vCPU</td>
+        <td>Xeon E5 v3 (Haswell)</td>
+        <td>2.3</td>
+        <td>45</td>
+        <td>DDR4</td>
+        <td>14.4</td>
+        <td>1600</td>
+        <td>56</td>
+        <td>Skypool Miner</td>
+        <td>Ubuntu</td>
+        <td>16</td>
+        <td>None</td>
+    </tr>
 </table>
 </div>	
 	<hr>


### PR DESCRIPTION
Google Cloud Haswell Xeon 16 vCPU (14.4GB RAM)